### PR TITLE
to display icon on snes mini

### DIFF
--- a/CloverApp/CLV-Z-RARCH.desktop
+++ b/CloverApp/CLV-Z-RARCH.desktop
@@ -3,7 +3,7 @@ Type=Application
 Exec=/bin/retroarch-mini null
 Path=/var/lib/clover/profiles/0/CLV-Z-RARCH
 Name=RetroArch
-Icon=/usr/share/games/nes/kachikachi/CLV-Z-RARCH/CLV-Z-RARCH.png
+Icon=/usr/share/games/CLV-Z-RARCH/CLV-Z-RARCH.png
 
 [X-CLOVER Game]
 Code=CLV-Z-RARCH


### PR DESCRIPTION
the broken icon slow the display of the folder which contains cloverapp icon
Repair the icon makes the folder display faster

i don't know if this fix works for nes mini also