### PR TITLE
Increased sleep timer for N64/GBA rom save bug

### DIFF
--- a/retroarch.hmod/bin/retroarch-clover-child
+++ b/retroarch.hmod/bin/retroarch-clover-child
@@ -107,7 +107,7 @@ if [ ! -z "$demo" ]; then
   fi
 fi
 
-sleep 3
+sleep 6
 rm -f /var/cache/*.state /var/cache/*.auto /var/cache/*.srm /var/cache/*.sav
 
 # Playing games until reset pressed


### PR DESCRIPTION
The sleep timer before /var/cache/* wipe was too short and was causing some games (like Mother 3) to fail to load the savestate or SRAM due to the files being deleted before the rom finished decompressing.  The community "fix" is to leave the rom decompressed, but NAND doesn't have much space and it was a less than ideal solution to leave things decompressed when we can just tweak this sleep timer.